### PR TITLE
Corrections to read AcquisXD files

### DIFF
--- a/Examples/Examples.py
+++ b/Examples/Examples.py
@@ -31,6 +31,18 @@ def read_XRD_generic_dataFile():
     X = DC.getFieldByName('angle')
     Y = DC.getFieldByName('signal')
 
+def readAcquisXD():
 
-read_PPMS_ACMS_dataFile()
-read_XRD_generic_dataFile()
+    from AsciiDataFile.Readers import GenericDataReader as Reader
+
+    dataPath = '/Users/oneminimax/Documents/Projets Physique/PCCO 17 Hall and Lin Res/Transport Data/FAB Samples/20180703B/Acquis'
+    dataFile = 'VrhoVH-vs-H-42K-HR.txt'
+
+    reader = Reader('\t',['temperature','champ','V1','V2','I'])
+
+    DC = reader.read(path.join(dataPath,dataFile))
+
+
+# read_PPMS_ACMS_dataFile()
+# read_XRD_generic_dataFile()
+readAcquisXD()

--- a/Readers.py
+++ b/Readers.py
@@ -9,8 +9,6 @@ class Reader(object):
 
     def read(self,filePath):
 
-        print('read')
-
         self._openFile(filePath)
         self._readHeader()
 
@@ -73,11 +71,14 @@ class Reader(object):
         DC = self._newDataContainer()
     
         while True:
-            keepreading, newData = self._readDataLine()
-            if keepreading:
-                if isinstance(newData,np.ndarray):
-                    DC.addDataPoint(newData)
-            else:
+            try:
+                keepreading, newData = self._readDataLine()
+                if keepreading:
+                    if isinstance(newData,np.ndarray):
+                        DC.addDataPoint(newData)
+                else:
+                    break
+            except:
                 break
 
         return DC
@@ -115,6 +116,14 @@ class GenericDataReader(Reader):
 
         for n in range(self._nbHeadLine):
             headerLines.append(self.fId.readline())
+
+# class AcquisXDDataFileReader(Reader):
+#     separator = '\t'
+
+#     def _readHeader(self):
+
+
+
 
 class MDDataFileReader(Reader):
     separator = ','
@@ -210,9 +219,15 @@ class PPMSResistivityDataReader(Reader):
 
     separator = ','
 
-    def __init__(self,sampleNumber = 0):
-        self.sampleNumber = sampleNumber
+    def __init__(self):
+        
         Reader.__init__(self)
+
+    def read(self,filePath,sampleNumber = 0):
+
+        self.sampleNumber = sampleNumber
+
+        return Reader.read(self,filePath)
         
 
     def _readHeader(self):


### PR DESCRIPTION
We can now read Acquis XD files with the Generic Reader. The Header needs to be provided by the user, like in the example.